### PR TITLE
Attempt to fix intermittent failures

### DIFF
--- a/spec/process_booking_spec.rb
+++ b/spec/process_booking_spec.rb
@@ -50,7 +50,14 @@ RSpec.feature 'process a booking', type: :feature do
     fill_in 'Reference number', with: '12345678'
 
     click_button 'Send email'
+
+    # The step below the sleep fails interminently, attempt to fix this with a
+    # hard sleep as I have already increased the retries from 10s to 20s.
+    sleep(1)
     confirmation_email = retry_for(20, ->(email) { email }) {
+      # Log how many messages the API is returning to help debugging intermitent
+      # issues.
+      STDOUT.puts "Matched messages: #{Mailtrap.instance.search_messages(visitor.email)}"
       Mailtrap.instance.search_messages(visitor.email).find do |email|
         email.subject =~ /^Visit confirmed/
       end


### PR DESCRIPTION
The spec is flapping for no apparent reason as the web interface for Mailtrap
has the emails that the spec fails on.