### PR TITLE
Update to use the contact list when processing

### DIFF
--- a/spec/process_booking_spec.rb
+++ b/spec/process_booking_spec.rb
@@ -48,6 +48,10 @@ RSpec.feature 'process a booking', type: :feature do
 
       fill_in 'Reference number', with: '12345678'
 
+      within '.visitor-contact-list' do
+        all('option')[1].select_option
+      end
+
       click_button 'Process'
 
       expect(page).to have_css('p.notification', text: 'Thank you for processing the visit')


### PR DESCRIPTION
Due to the recent work on enforcing the contact list tests started failing in
staging. The dev environment has been updated to use the contact list so the
behavour should be the same between the 2 test environments.