### PR TITLE
Remove Firefox browser warning - no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ When configuring SMTP (get the credentials by logging into mailtrap), note that 
 3. Start PVB Public (app)
 4. Run tests
 
-*NOTE* - It is recommended you run using Firefox browser <= 57.0.4 as more recent versions can cause issues with Capybara and clicking button elements.
-
 ## Test Configuration
 
 I recommend copying `.env.example` to `.env` and using direnv to automatically load these configuration variables (`brew install direnv`).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,24 +10,8 @@ Capybara.default_max_wait_time = 10
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.before(:all) do
-    check_firefox_version
     page.driver.browser.manage.window.resize_to(1920, 1080)
   end
-end
-
-def check_firefox_version
-  session = Capybara.current_session
-  driver = session.driver
-  version = driver.browser.capabilities.version
-  version_minor = version.split('.').take(2).join('.').to_f
-  puts firefox_warning(version_minor) if version_minor > 57.0
-end
-
-def firefox_warning(version)
-  <<-HEREDOC
-    Warning! Capybara is testing against Firefox version: #{version}.
-    Capybara may experience problems clicking buttons for any version greater than 57.0.X
-  HEREDOC
 end
 
 require_relative 'helpers/google_analytics_helper'


### PR DESCRIPTION
Latest versions of Capybara used to run into problems with the latest versions of Firefox, however this no longer seems to be the case. 