### PR TITLE
Remove reference to book to nomis (feature no longer exists)

### DIFF
--- a/spec/integration/process_booking_spec.rb
+++ b/spec/integration/process_booking_spec.rb
@@ -30,8 +30,7 @@ RSpec.feature 'process a booking', type: :feature do
   end
 
   describe 'accept booking' do
-    context 'with book to nomis disabled' do
-      scenario 'then visitor cancels' do
+    scenario 'then visitor cancels' do
         make_booking(prisoner, visitor)
 
         login_as_staff
@@ -79,7 +78,6 @@ RSpec.feature 'process a booking', type: :feature do
         sleep(1)
         expect(google_analytics.pvb2_url_count('/visit-requested')).to be > 0
       end
-    end
   end
 
   describe 'clean up inboxes' do


### PR DESCRIPTION
Part of the work to remove the 'book to nomis' feature
https://trello.com/c/HSbKrMAv/132-remove-book-to-nomis-feature