### PR TITLE
Fix cancellation spec

### DIFF
--- a/spec/integration/process_booking_spec.rb
+++ b/spec/integration/process_booking_spec.rb
@@ -70,6 +70,7 @@ RSpec.feature 'process a booking', type: :feature do
         cancel_url = email_link_href(confirmation_email, 'you can cancel this visit')
         visit cancel_url
         expect(page).to have_content('Your visit has been confirmed')
+        find('summary').click
         check_yes_cancel
         click_button 'Cancel visit'
         expect(page).to have_content('Your visit is cancelled')


### PR DESCRIPTION
The visitor's confirmed booking page has been changed to include a new
element which hid the "yes I want to cancel this visit" checkbox.  As a
result the related integration test started failing as it could no
longer scroll that element into view.  I have added the required step to
click this new link in order for the checkbox to be found.