### PR TITLE
Update tests re: Mailtrap API changes

### DIFF
--- a/spec/integration/basic_spec.rb
+++ b/spec/integration/basic_spec.rb
@@ -71,7 +71,10 @@ RSpec.feature 'booking a visit', type: :feature do
     # Since the email is unique only a single email should have been returned
     expect(emails.size).to eq(1)
     email = emails.first
-    status_url = email.capybara.find_link('visit status page')[:href]
+    email_body = Mailtrap.instance.message_body(email.html_path)
+
+    status_url = email_body.find_link('visit status page')[:href]
+
 
     # Status page
     visit status_url

--- a/spec/integration/process_booking_spec.rb
+++ b/spec/integration/process_booking_spec.rb
@@ -67,7 +67,10 @@ RSpec.feature 'process a booking', type: :feature do
           visitor_emails.find { |email| email.subject =~ /^Visit confirmed/ }
         end
 
-        cancel_url = email_link_href(confirmation_email, 'you can cancel this visit')
+        email_body = Mailtrap.instance.message_body(confirmation_email.html_path)
+
+        cancel_url = email_body.find_link('you can cancel this visit')[:href]
+
         visit cancel_url
         expect(page).to have_content('Your visit has been confirmed')
         find('summary').click

--- a/spec/lib/mailtrap.rb
+++ b/spec/lib/mailtrap.rb
@@ -11,9 +11,9 @@ class Mailtrap
     end
   end
 
-  Email = Struct.new(:to_name, :to_email, :subject, :text_body, :html_body) do
+  Email = Struct.new(:to_name, :to_email, :subject, :txt_path, :html_path) do
     def self.parse(hash)
-      new(*hash.values_at('to_name', 'to_email', 'subject', 'text_body', 'html_body'))
+      new(*hash.values_at('to_name', 'to_email', 'subject', 'txt_path', 'html_path'))
     end
 
     def capybara
@@ -42,16 +42,19 @@ class Mailtrap
     messages.map { |e| Email.parse(e) }
   end
 
+  def message_body(path)
+    response = @connection.get(
+      path: path,
+      expects: [200],
+      idempotent: true
+    )
+    Capybara.string(response.body)
+  end
+
   # The search API is rather limited: AFAICT it's something like a prefix match
   # on to, from, subject
   def search_messages(search)
     inbox_messages(search: search)
-  end
-
-  # This is not supported by the API, so this is inefficient!
-  def search_body(search_regexp)
-    emails = inbox_messages
-    emails.find_all { |e| e.text_body =~ search_regexp }
   end
 end
 


### PR DESCRIPTION
Mailtrap changed their API over the weekend and this resulted in two of
our tests failing.  The "text_body" field is now returned with a
deprecation warning and a secondary API call has to be made to get the
body of the email.

There is the opportunity for further refactoring in the mailtrap.rb file
and the way we are making the now required second API call to get the
body of the email.

In addition to this it was established that a method was no longer being
used (search_body) so this has been removed.