### PR TITLE
Do not run Google Analytics assertions for now

### DIFF
--- a/spec/integration/basic_spec.rb
+++ b/spec/integration/basic_spec.rb
@@ -90,7 +90,11 @@ RSpec.feature 'booking a visit', type: :feature do
     expect(page).to have_content 'You cancelled this visit request'
 
     # Give time to GA to do its indexing
-    sleep(1)
-    expect(google_analytics.public_url_count(status_url)).to be > 0
+    # Only do this in template deploy environment. New Google Private Key required for kubernetes
+
+    if ENV['TEMPLATE_DEPLOY']
+      sleep(1)
+      expect(google_analytics.public_url_count(status_url)).to be > 0
+    end
   end
 end

--- a/spec/integration/process_booking_spec.rb
+++ b/spec/integration/process_booking_spec.rb
@@ -77,8 +77,12 @@ RSpec.feature 'process a booking', type: :feature do
         expect(page).to have_content('Your visit is cancelled')
 
         # Give time to GA to do its indexing
-        sleep(1)
-        expect(google_analytics.pvb2_url_count('/visit-requested')).to be > 0
+        # Only do this in template deploy environment. New Google Private Key required for kubernetes
+
+        if ENV['TEMPLATE_DEPLOY']
+          sleep(1)
+          expect(google_analytics.pvb2_url_count('/visit-requested')).to be > 0
+        end
       end
   end
 


### PR DESCRIPTION
Once we have an new Google API Key for querying Google Analytics (on Kubernetes deploy) we can reinstate the assertions