### PR TITLE
Click continue button programatically

### DIFF
--- a/spec/helpers/step_helper.rb
+++ b/spec/helpers/step_helper.rb
@@ -41,15 +41,23 @@ def make_booking(prisoner, visitor)
   fill_in_prisoner_step(prisoner)
   fill_in 'Prisoner number', with: prisoner.number
   fill_in 'Prison name', with: ENV.fetch('PRISON')
-  page.execute_script('$("input[value=\"Continue\"]").trigger("click")')
+  click_continue
 
   expect(page).to have_css('h1', text: 'When do you want to visit?')
   select_first_available_date_and_slot
   click_link 'No more to add'
   fill_in_visitor_step(visitor)
-  click_button 'Continue'
+  click_continue
   click_button 'Send visit request'
   expect(page).to have_content 'Visit request sent'
+end
+
+# for reasons not completely understood, sometimes capybara can't find
+# the continue button to click on because it is just off-screen
+# so do it programmatically instead.
+def click_continue
+  page.execute_script('$("input[value=\"Continue\"]").trigger("click")')
+  # click_button 'Continue'
 end
 
 def fill_in_prisoner_step(prisoner)

--- a/spec/integration/basic_spec.rb
+++ b/spec/integration/basic_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'booking a visit', type: :feature do
     fill_in_prisoner_step(prisoner)
 
     fill_in 'Prisoner number', with: 'Z0000AA'
-    click_button 'Continue'
+    click_continue
     expect(page).to have_css(
       'fieldset span.error-message',
       text: 'No prisoner matches the details you’ve supplied, please ask the prisoner to check your details are correct',
@@ -41,7 +41,7 @@ RSpec.feature 'booking a visit', type: :feature do
 
     # Booking: Step 1 (prisoner)
     fill_in 'Prisoner number', with: prisoner.number
-    click_button 'Continue'
+    click_continue
 
     # Booking: Step 2 (pick 1 slot)
     expect(page).to have_css 'h1', text: 'When do you want to visit?'
@@ -51,7 +51,7 @@ RSpec.feature 'booking a visit', type: :feature do
     # Booking: Step 3 (visitors)
     expect(page).to have_content 'Visitor details'
     fill_in_visitor_step(visitor)
-    click_button 'Continue'
+    click_continue
 
     # Booking: Step 4 (summary)
     expect(page).to have_content 'Check your visit details'

--- a/spec/lib/mailtrap.rb
+++ b/spec/lib/mailtrap.rb
@@ -21,6 +21,25 @@ class Mailtrap
     )
   end
 
+  def clean
+    @connection.patch(
+      path: '/api/v1/inboxes/106414/clean',
+      expects: [200],
+      idempotent: true
+    )
+  end
+
+  def clean_if_full
+    response = @connection.get(
+      path: '/api/v1/inboxes',
+      expects: [200],
+      idempotent: true
+    )
+    inbox = JSON.parse(response.body, symbolize_names: true).first
+    # 'full' means enough space to receive all the emails from this test
+    clean if inbox.fetch(:max_size) - inbox.fetch(:emails_count) < 5
+  end
+
   def inbox_messages(query = {})
     response = @connection.get(
       path: '/api/v1/inboxes/106414/messages',

--- a/spec/smoke/basic_spec.rb
+++ b/spec/smoke/basic_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'booking a visit', type: :feature do
     fill_in_prisoner_step(invalid_prisoner)
     fill_in 'Prisoner number', with: INVALID_PRISONER_NUMBER
 
-    click_button 'Continue'
+    click_continue
 
     expect(page).to have_css(
       'fieldset span.error-message',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.before(:all) do
     page.driver.browser.manage.window.resize_to(1920, 1080)
+    # prevent mailtrap inbox from filling up
+    Mailtrap.instance.clean_if_full
   end
 end
 


### PR DESCRIPTION
The integration tests need to click the 'Continue' button programatically as it appears to be tantalisingly off-screen in a few scenarios. Also we were filling up mailtrap causing tests to fail, so clear that out if we hit the maximum number of messages.